### PR TITLE
Adds the ability to log exceptions to an error logger such as Rollbar

### DIFF
--- a/lib/socrates/configuration.rb
+++ b/lib/socrates/configuration.rb
@@ -17,12 +17,14 @@ module Socrates
     attr_accessor :error_message
     attr_accessor :expired_timeout # seconds
     attr_accessor :logger
+    attr_accessor :error_logger # For caught exceptions, replace with your own logger, such as Rollbar
 
     def initialize
       @storage         = Storage::Memory.new
       @error_message   = "Sorry, something went wrong. We'll have to start over..."
       @expired_timeout = 30.minutes
       @logger          = Socrates::Logger.default
+      @error_logger    = Socrates::Logger.default
     end
   end
 end

--- a/lib/socrates/core/dispatcher.rb
+++ b/lib/socrates/core/dispatcher.rb
@@ -18,6 +18,7 @@ module Socrates
         @storage       = storage || Socrates.config.storage
 
         @logger        = Socrates.config.logger
+        @error_logger  = Socrates.config.error_logger
         @error_message = Socrates.config.error_message || DEFAULT_ERROR_MESSAGE
       end
 
@@ -151,8 +152,10 @@ module Socrates
       end
 
       def handle_action_error(error, session, state)
-        @logger.warn "Error while processing action #{state.data.state_id}/#{state.data.state_action}: #{error.message}"
-        @logger.warn error
+        @error_logger.error "Error while processing action \
+          #{state.data.state_id}/#{state.data.state_action}: #{error.message}"
+        @error_logger.error "For user: #{session.user}"
+        @error_logger.error error
 
         @adapter.queue_message(session, @error_message, send_now: true)
 

--- a/lib/socrates/storage/storage.rb
+++ b/lib/socrates/storage/storage.rb
@@ -4,7 +4,7 @@ module Socrates
   module Storage
     module Storage
       def initialize
-        @logger = Socrates.config.logger
+        @error_logger = Socrates.config.error_logger
       end
 
       def fetch(client_id)
@@ -17,8 +17,9 @@ module Socrates
         begin
           Socrates::Core::StateData.deserialize(snapshot)
         rescue StandardError => e
-          @logger.warn "Error while fetching state_data for client id '#{client_id}', resetting state: #{e.message}"
-          @logger.warn e
+          @error_logger.error "Error while fetching state_data for client id '#{client_id}', /
+            resetting state: #{e.message}"
+          @error_logger.error e
         end
       end
 


### PR DESCRIPTION
Before, you could only log to a logger. This was great for using Papertrail, but not as good if you wanted to use Rollbar for error tracking.

Now, you have an error logger, in addition to a logger, which you can pass in to use Rollbar or a similar service.