### PR TITLE
Bug fix: Auto reconnect Slack RTC if bot goes offline

### DIFF
--- a/lib/socrates.rb
+++ b/lib/socrates.rb
@@ -14,6 +14,7 @@ require "socrates/core/state"
 require "socrates/core/dispatcher"
 require "socrates/bots/cli"
 require "socrates/bots/slack"
+require "socrates/bots/slack/ping"
 
 module Socrates
 end

--- a/lib/socrates/bots/slack/ping.rb
+++ b/lib/socrates/bots/slack/ping.rb
@@ -1,0 +1,28 @@
+module Socrates
+  module Bots
+    class Slack
+      class Ping
+        def initialize
+          logger = Logger.new(STDOUT)
+          # The ping is going to run every minute, so don't be too chatty
+          logger.level = Logger::WARN
+
+          @client = ::Slack::Web::Client.new(
+            token: ENV.fetch("SLACK_API_TOKEN"),
+            logger: logger
+          )
+        end
+
+        def alive?
+          auth = client.auth_test
+          presence = client.users_getPresence(user: auth["user_id"])
+          presence.online?
+        end
+
+        private
+
+        attr_reader :client
+      end
+    end
+  end
+end

--- a/lib/socrates/configuration.rb
+++ b/lib/socrates/configuration.rb
@@ -17,7 +17,8 @@ module Socrates
     attr_accessor :error_message
     attr_accessor :expired_timeout # seconds
     attr_accessor :logger
-    attr_accessor :error_handler   # a callable proc
+    attr_accessor :error_handler   # a callable like ->(String, Exception) { ... }
+    attr_accessor :warn_handler    # a callable like ->(String) { ... }
 
     def initialize
       @storage         = Storage::Memory.new
@@ -25,6 +26,7 @@ module Socrates
       @expired_timeout = 30.minutes
       @logger          = Socrates::Logger.default
       @error_handler   = proc { |_message, _error| }
+      @warn_handler    = proc { |_message| }
     end
   end
 end


### PR DESCRIPTION
We are seeing a problem where the Slack real-time client occasionally disconnects silently. In this scenario the bot user goes offline but the Ruby process doesn't crash and the RTC still seems to be connected.

As a workaround, this commit introduces a Ping class that can be used to check wither the bot is online. It uses the Slack web client to do this (the RTC does not have an API to check online status).

Then, when starting the bot, we first open the RTC and then enter a loop where we use the Ping every minute. If the bot ever goes offline, we stop the RTC and re-open it. When this happens we also send a message to the logs and to the `warn_handler` (e.g. Rollbar).

This solution was inspired by this GitHub comment:
slack-ruby/slack-ruby-client#208 (comment)