### PR TITLE
Switch to async-websocket from celluloid

### DIFF
--- a/socrates.gemspec
+++ b/socrates.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.16"
   spec.add_development_dependency "timecop", "~> 0.9"
 
-  spec.add_dependency "activesupport", ">= 5.1"
-  spec.add_dependency "celluloid-io", ">= 0.17.3"
+  spec.add_dependency "activesupport", ">= 5.2"
+  spec.add_dependency "async-websocket", ">= 0.7"
   spec.add_dependency "hashie", ">= 3.6"
-  spec.add_dependency "redis", ">= 4.0.3"
-  spec.add_dependency "slack-ruby-client", ">= 0.13.1"
+  spec.add_dependency "redis", ">= 4.1"
+  spec.add_dependency "slack-ruby-client", ">= 0.14.1"
 end


### PR DESCRIPTION
`async-websocket` is the preferred dependency these days, so switch socrates to use it as well.

This doesn't change any code with socrates, since it's really a dependency of the slack-ruby-gem.