### PR TITLE
Remove Rails cops from RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,109 @@
-inherit_from:
-  - https://raw.githubusercontent.com/carbonfive/c5-conventions/master/rubocop/rubocop.yml
+require:
+  - rubocop-performance
 
 AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
   TargetRubyVersion: 2.4
+  Exclude:
+    - "bin/*"
+    - "db/schema.rb"
+    - "lib/templates/**/*"
+    - "**/node_modules/**/*"
+    - "tmp/**/*"
+    - "vendor/**/*"
+    - "log/**/*"
 
-Naming/MethodParameterName:
+#
+# Ruby Cops
+#
+
+Layout/CaseIndentation:
   Enabled: false
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/HashAlignment:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 120
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+Lint/ScriptPermission:
+  Exclude:
+    - "Rakefile"
+
+Metrics/AbcSize:
+  Max: 35
+  Exclude:
+    - "spec/**/*"
+
+Metrics/BlockLength:
+  CountComments: false
+  Max: 50
+  Exclude:
+    - "config/**/*"
+    - "spec/**/*"
+
+Metrics/ClassLength:
+  Max: 250
+  Exclude:
+    - "spec/**/*"
+
+Metrics/MethodLength:
+  Max: 25
+  Exclude:
+    - "db/migrate/*"
+    - "spec/**/*"
+
+Naming/PredicateName:
+  Enabled: false
+
+Performance/Casecmp:
+  Enabled: false
+
+Security/YAMLLoad:
+  Enabled: false
+
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining
+
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Style/Lambda:
+  EnforcedStyle: literal
+
+Style/ModuleFunction:
+  EnforcedStyle: extend_self
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/PreferredHashMethods:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/StructInheritance:
+  Enabled: true


### PR DESCRIPTION
### Problem

Before, we were inheriting our rubocop config from the c5-conventions repo. That config has changed over time to include things that are specific to Rails. This makes sense, because 99% of the time when we are using rubocop, it is on Rails projects. However this caused rubocop in socrates to break: the c5-conventions assume the presence of the `rubocop-rails` gem, which socrates does not have.

```
$ bundle exec rubocop
cannot load such file -- rubocop-rails
```

### Solution

Fix by copying the c5-conventions rubocop.yml directly into this project, then manually modify to remove the Rails-specific stuff.

Note that since we are no longer inheriting from c5-conventions, this copied config might "drift" or become out of date compared to the latest c5-conventions. I feel like this is an acceptable compromise because overhauling the conventions themselves to accommodate non-Rails projects (e.g. splitting into two files, Rails and non-Rails) seems like a lot of work and ongoing maintenance in order to support the 1% of projects like socrates that would benefit.