### PR TITLE
Update to latest rubocop gems; simplify rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
+  NewCops: enable
   TargetRubyVersion: 2.4
   Exclude:
     - "bin/*"
@@ -21,36 +22,21 @@ AllCops:
 Layout/CaseIndentation:
   Enabled: false
 
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Layout/HashAlignment:
   Enabled: false
 
-Layout/LineLength:
-  Max: 120
-
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
 
 Lint/AmbiguousBlockAssociation:
   Enabled: false
 
-Lint/RaiseException:
-  Enabled: true
-
 Lint/ScriptPermission:
   Exclude:
     - "Rakefile"
-
-Lint/StructNewOverride:
-  Enabled: true
 
 Metrics/AbcSize:
   Max: 35
@@ -84,6 +70,9 @@ Performance/Casecmp:
 Security/YAMLLoad:
   Enabled: false
 
+Style/AccessorGrouping:
+  Enabled: false
+
 Style/BarePercentLiterals:
   EnforcedStyle: percent_q
 
@@ -96,20 +85,8 @@ Style/Documentation:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
-Style/ExponentialNotation:
-  Enabled: true
-
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
 
 Style/Lambda:
   EnforcedStyle: literal
@@ -131,6 +108,3 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
-
-Style/StructInheritance:
-  Enabled: true

--- a/socrates.gemspec
+++ b/socrates.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.1.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "rubocop", "= 0.83.0"
-  spec.add_development_dependency "rubocop-performance", "= 1.5.2"
+  spec.add_development_dependency "rubocop", "= 0.88.0"
+  spec.add_development_dependency "rubocop-performance", "= 1.7.0"
   spec.add_development_dependency "simplecov", "~> 0.16"
   spec.add_development_dependency "timecop", "~> 0.9"
 


### PR DESCRIPTION
By default, rubocop makes you explicitly opt in or out of new rules that are added in each release. Otherwise it loudly prints warnings to the console. This is annoying and makes updating gems tedious. In practice, we almost always end up enabling the new rules.

This commit updates our rubocop config with:

```
NewCops: enable
```

This automatically opts us into any new rules that are added. That means there is no need to explicitly enable individual rules, and so our rubocop config becomes much smaller.

This commit updates rubocop and rubocop-performance to their latest versions and thus enables all the new rules that have been added in those versions. The only rule that caused violations (and that I have disabled), is `Style/AccessorGrouping`.