### PR TITLE
Inherit directly from new C5 rubocop conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
-/.rubocop-https---raw-githubusercontent-com-carbonfive-c5-conventions-master-rubocop-rubocop-yml
+/.rubocop-https---*
 /socrates-*.gem
 
 # rspec failure tracking

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,110 +1,12 @@
 require:
   - rubocop-performance
 
+inherit_from:
+  - https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop-common.yml
+  - https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop-performance.yml
+
 AllCops:
-  DisplayCopNames: true
-  DisplayStyleGuide: true
-  NewCops: enable
-  TargetRubyVersion: 2.4
-  Exclude:
-    - "bin/*"
-    - "db/schema.rb"
-    - "lib/templates/**/*"
-    - "**/node_modules/**/*"
-    - "tmp/**/*"
-    - "vendor/**/*"
-    - "log/**/*"
-
-#
-# Ruby Cops
-#
-
-Layout/CaseIndentation:
-  Enabled: false
-
-Layout/FirstArrayElementIndentation:
-  EnforcedStyle: consistent
-
-Layout/HashAlignment:
-  Enabled: false
-
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-
-Lint/AmbiguousBlockAssociation:
-  Enabled: false
-
-Lint/ScriptPermission:
-  Exclude:
-    - "Rakefile"
-
-Metrics/AbcSize:
-  Max: 35
-  Exclude:
-    - "spec/**/*"
-
-Metrics/BlockLength:
-  CountComments: false
-  Max: 50
-  Exclude:
-    - "config/**/*"
-    - "spec/**/*"
-
-Metrics/ClassLength:
-  Max: 250
-  Exclude:
-    - "spec/**/*"
-
-Metrics/MethodLength:
-  Max: 25
-  Exclude:
-    - "db/migrate/*"
-    - "spec/**/*"
-
-Naming/PredicateName:
-  Enabled: false
-
-Performance/Casecmp:
-  Enabled: false
-
-Security/YAMLLoad:
-  Enabled: false
+  TargetRubyVersion: 2.4 # this must match gemspec required_ruby_version
 
 Style/AccessorGrouping:
   Enabled: false
-
-Style/BarePercentLiterals:
-  EnforcedStyle: percent_q
-
-Style/BlockDelimiters:
-  EnforcedStyle: braces_for_chaining
-
-Style/Documentation:
-  Enabled: false
-
-Style/EmptyMethod:
-  EnforcedStyle: expanded
-
-Style/FrozenStringLiteralComment:
-  EnforcedStyle: never
-
-Style/Lambda:
-  EnforcedStyle: literal
-
-Style/ModuleFunction:
-  EnforcedStyle: extend_self
-
-Style/MutableConstant:
-  Enabled: false
-
-Style/PreferredHashMethods:
-  Enabled: false
-
-Style/SlicingWithRange:
-  Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-
-Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes


### PR DESCRIPTION
The c5-conventions repo now breaks up the rubocop config per plugin, so it can be used by non-Rails projects. This means we can inherit directly from the conventions without maintaining our own copy.