### PR TITLE
Pluggable event tracking for start_conversation and state transitions

### DIFF
--- a/lib/socrates/configuration.rb
+++ b/lib/socrates/configuration.rb
@@ -19,6 +19,7 @@ module Socrates
     attr_accessor :logger
     attr_accessor :error_handler   # a callable like ->(String, Exception) { ... }
     attr_accessor :warn_handler    # a callable like ->(String) { ... }
+    attr_accessor :event_handler   # a callable like ->(Session, Event, Data) { ... }
 
     def initialize
       @storage         = Storage::Memory.new
@@ -27,6 +28,7 @@ module Socrates
       @logger          = Socrates::Logger.default
       @error_handler   = proc { |_message, _error| }
       @warn_handler    = proc { |_message| }
+      @event_handler   = proc { |_session, _event, _data| }
     end
   end
 end

--- a/lib/socrates/configuration.rb
+++ b/lib/socrates/configuration.rb
@@ -28,7 +28,9 @@ module Socrates
       @logger          = Socrates::Logger.default
       @error_handler   = proc { |_message, _error| }
       @warn_handler    = proc { |_message| }
-      @event_handler   = proc { |_session, _event, _data| }
+      @event_handler   = proc { |_session, event, data|
+        puts ">>> #{event}: #{data.inspect}"
+      }
     end
   end
 end


### PR DESCRIPTION
Reopening PR #15 that was closed inadvertently when I renamed the default branch to `main`.

Original PR description from @christiannelson 

> A developer might want to track key events using something like MixPanel. This provides a simple callback for plugging in a handler that delegates to whatever the developer chooses.