### PR TITLE
"im.open" is now deprecated

### DIFF
--- a/lib/socrates/adapters/slack.rb
+++ b/lib/socrates/adapters/slack.rb
@@ -73,7 +73,7 @@ module Socrates
         return im if im.present?
 
         # Start a new conversation with this user.
-        response = @real_time_client.web_client.conversations_open(user: user.id)
+        response = @real_time_client.web_client.conversations_open(users: user.id)
         response.channel.id
       end
     end

--- a/lib/socrates/adapters/slack.rb
+++ b/lib/socrates/adapters/slack.rb
@@ -73,7 +73,7 @@ module Socrates
         return im if im.present?
 
         # Start a new conversation with this user.
-        response = @real_time_client.web_client.im_open(user: user.id)
+        response = @real_time_client.web_client.conversations_open(user: user.id)
         response.channel.id
       end
     end


### PR DESCRIPTION
**Problem**
```im.open: This method is deprecated. It will stop functioning in February 2021 and will not work with newly created apps after June 10th, 2020. Alternative methods: conversations.open.```

**Solution**
Use "conversations.open" instead, as per [the documentation](https://api.slack.com/methods/im.open).