### PR TITLE
Use exists? for boolean return instead of integer

### DIFF
--- a/lib/socrates/storage/redis.rb
+++ b/lib/socrates/storage/redis.rb
@@ -12,7 +12,7 @@ module Socrates
       end
 
       def has_key?(key)
-        @redis.exists(key)
+        @redis.exists?(key)
       end
 
       def clear(key)


### PR DESCRIPTION
**Problem**

`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0. (/app/vendor/bundle/ruby/3.0.0/bundler/gems/socrates-52d9c7a4e167/lib/socrates/storage/redis.rb:15:in `has_key?') 

**Solution**

Use `.exists?` instead.